### PR TITLE
docs: add docs and runnable examples

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,105 @@
+# Advanced usage
+
+Recipes and edge cases for `lingua_podre`. The detector is intentionally tiny;
+most of the work is knowing where it goes flat.
+
+## Empty and undetectable input
+
+The scoring path divides by the total number of matched tokens. When nothing
+matches — a single rare word, a proper name, a non-bundled language — that total
+is 0:
+
+- `get_word_counts` returns `{}`
+- `get_lang_scores` raises `ZeroDivisionError`
+- `predict_lang` raises `ValueError` (`max()` on an empty set)
+
+Always guard arbitrary input:
+
+```python
+from lingua_podre import predict_lang, get_word_counts
+
+def detect(text):
+    if not get_word_counts(text):       # cheap pre-check, never raises
+        return []
+    return predict_lang(text)
+
+detect("xyzzy")     # []
+detect("olá mundo") # ['pt']
+```
+
+## Ties
+
+`predict_lang` returns every code that holds the top score, so a list of length
+> 1 means the text was ambiguous. This is common for short input, and especially
+for the Romance and Slavic clusters that share many function words.
+
+```python
+from lingua_podre import predict_lang
+
+result = predict_lang("a")          # 'a' appears in many lists
+if len(result) > 1:
+    print("ambiguous:", result)     # break the tie with more context
+```
+
+Tie-breaking strategy: feed more text. The signal is per-token, so longer input
+sharpens the distribution.
+
+## Reading the distribution instead of the top pick
+
+When you want a confidence-style answer rather than a hard label, use the scores
+directly:
+
+```python
+from lingua_podre import get_lang_scores
+
+scores = get_lang_scores("olá o meu nome é João")
+ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+for code, p in ranked[:3]:
+    print(f"{code}: {p:.0%}")
+```
+
+A simple confidence threshold — accept only when the top score clears, say, 0.25
+and beats the runner-up by a margin — filters out the flat distributions you get
+from short or mixed text.
+
+## Supported languages
+
+The active set is whatever is in `langs` (28 codes). Inspect it at runtime
+rather than hardcoding:
+
+```python
+from lingua_podre import langs
+for code, name in sorted(langs.items()):
+    print(code, name)
+```
+
+The package ships more word-list files than it loads — only languages listed in
+`res/languages.json` (mirrored by `langs`) are active. A token from an
+unsupported language will not match and contributes nothing.
+
+## Pre-tokenising
+
+`get_word_counts` accepts an already-tokenised `list[str]`, which lets you swap
+in your own tokeniser (the built-in `tokenize` only lowercases and splits on
+spaces, keeping punctuation attached):
+
+```python
+import re
+from lingua_podre import get_word_counts, get_lang_scores
+
+def words(text):
+    return re.findall(r"\w+", text.lower())
+
+toks = words("Olá, o meu nome é João!")   # punctuation stripped
+get_word_counts(toks)                      # cleaner matches than the default split
+```
+
+`get_lang_scores` and `predict_lang` always tokenise internally with the built-in
+splitter, so to use a custom tokeniser end-to-end, call `get_word_counts`
+yourself and normalise the counts.
+
+## Where next
+
+- [api.md](api.md) — exact signatures and return shapes
+- [opm.md](opm.md) — wiring it into an OVOS pipeline
+- [quickstart.md](quickstart.md) — the basics

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,115 @@
+# API reference
+
+Everything public lives at the top level of `lingua_podre`. The detector is four
+small functions plus the data they read.
+
+```python
+from lingua_podre import (
+    tokenize, get_word_counts, get_lang_scores, predict_lang,
+    langs, lang_codes, stopwords,
+)
+```
+
+## Functions
+
+### `tokenize(text) -> list[str]`
+
+Lowercases the text and splits on a single space.
+
+```python
+from lingua_podre import tokenize
+tokenize("Olá Mundo")           # ['olá', 'mundo']
+```
+
+It splits on `" "` only — it does not strip punctuation, so `"João,"` stays
+`"joão,"`. Tokens are matched against the word lists verbatim, so trailing
+punctuation simply fails to match.
+
+### `get_word_counts(text) -> dict[str, int]`
+
+Counts, per language code, how many tokens of `text` appear in that language's
+word list. Accepts either a raw string (it tokenises for you) or an
+already-tokenised `list[str]`.
+
+```python
+from lingua_podre import get_word_counts
+get_word_counts("olá o meu nome é João")
+# {'ca': 1, 'pt': 4, 'es': 1, 'pl': 1, 'tr': 1, 'ro': 2, 'it': 2, 'cs': 1, 'sk': 1}
+```
+
+A token that appears in several languages' lists is counted once per language —
+that is the whole signal. Only language codes with at least one hit are keys.
+
+### `get_lang_scores(text) -> dict[str, float]`
+
+`get_word_counts` divided by the total count, so the values sum to 1. Same key
+set as `get_word_counts`.
+
+```python
+from lingua_podre import get_lang_scores
+get_lang_scores("olá o meu nome é João")
+# {'pt': 0.285..., 'ro': 0.142..., 'it': 0.142..., 'ca': 0.071..., ...}
+```
+
+Raises `ZeroDivisionError` when no token matches anything (total is 0). See
+[advanced.md](advanced.md#empty-and-undetectable-input).
+
+### `predict_lang(text) -> list[str]`
+
+The top-scoring language code(s). Returns a **list** because ties are possible.
+
+```python
+from lingua_podre import predict_lang
+predict_lang("olá o meu nome é João")   # ['pt']
+```
+
+Raises `ValueError` on text where nothing matched (it calls `max()` on the empty
+score set). Wrap it if input can be arbitrary.
+
+## Module data
+
+### `langs -> dict[str, str]`
+
+Code to English name, for the 28 active languages. Loaded from
+`res/languages.json`, with an in-code fallback.
+
+```python
+from lingua_podre import langs
+langs["pt"]                 # 'portuguese'
+len(langs)                  # 28
+```
+
+### `lang_codes -> dict[str, str]`
+
+The inverse of `langs` — English name to code.
+
+```python
+from lingua_podre import lang_codes
+lang_codes["portuguese"]    # 'pt'
+```
+
+### `stopwords -> dict[str, list[str]]`
+
+Code to its loaded word list. Built once at import time from `res/stopwords/`
+and `res/1000/`. Only languages present in `langs` are loaded.
+
+```python
+from lingua_podre import stopwords
+sorted(stopwords)           # ['ar', 'bg', 'ca', 'cs', ...]  (28 codes)
+"meu" in stopwords["pt"]    # True
+```
+
+## Return-shape summary
+
+| Call | Returns | Empty / no-match behaviour |
+| --- | --- | --- |
+| `tokenize(text)` | `list[str]` | `['']` for empty string |
+| `get_word_counts(text)` | `dict[str, int]` | `{}` |
+| `get_lang_scores(text)` | `dict[str, float]` (sums to 1) | raises `ZeroDivisionError` |
+| `predict_lang(text)` | `list[str]` (codes) | raises `ValueError` |
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and first call
+- [advanced.md](advanced.md) — ties, guards, supported languages
+- [opm.md](opm.md) — the OVOS plugin wrapper

--- a/docs/opm.md
+++ b/docs/opm.md
@@ -1,0 +1,45 @@
+# OVOS plugin
+
+`lingua_podre` ships an OVOS Plugin Manager language detector so the same
+word-list engine plugs into an OVOS voice stack without any glue code.
+
+## The class
+
+`lingua_podre.opm.LinguaPodrePlugin` subclasses
+`ovos_plugin_manager.templates.language.LanguageDetector` and forwards to the
+two top-level functions:
+
+```python
+from lingua_podre.opm import LinguaPodrePlugin
+
+detector = LinguaPodrePlugin()
+detector.detect("olá o meu nome é João")        # ['pt']   -> predict_lang
+detector.detect_probs("olá o meu nome é João")  # {...}    -> get_lang_scores
+```
+
+- `detect(text)` returns the top language code(s), the same list `predict_lang`
+  produces.
+- `detect_probs(text)` returns the normalised score distribution from
+  `get_lang_scores`.
+
+Both inherit `predict_lang`/`get_lang_scores` behaviour exactly, including the
+exceptions on unmatched text — see
+[advanced.md](advanced.md#empty-and-undetectable-input). Guard the input the same
+way before handing it to the plugin.
+
+## Entry point
+
+The plugin registers under the OPM language-detector group:
+
+```
+ovos-lang-detector-plugin-lingua-podre = lingua_podre.opm:LinguaPodrePlugin
+```
+
+Once installed, OVOS discovers it by that name; you select it through your OVOS
+language configuration rather than importing it directly.
+
+## Where next
+
+- [api.md](api.md) — the functions the plugin wraps
+- [advanced.md](advanced.md) — guarding undetectable input
+- [quickstart.md](quickstart.md) — the engine on its own

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,77 @@
+# Quickstart
+
+`lingua_podre` is a word-list language detector in pure Python. It scores a piece
+of text by counting how many of its tokens appear in per-language stopword and
+top-word lists, normalises those counts to probabilities, and returns the most
+likely language code. No model, no download, no network — the word lists ship
+inside the package.
+
+## 1. Install
+
+```bash
+pip install lingua_podre        # from PyPI
+pip install -e .                # from a checkout
+```
+
+There are zero runtime dependencies. The OVOS plugin entry point
+([opm.md](opm.md)) additionally needs `ovos-plugin-manager`, but the detector
+functions themselves do not.
+
+## 2. The one idea
+
+Every supported language has a bundled list of common words. Tokenise the input,
+count how many tokens land in each language's list, and the language with the
+most hits wins. Counts are normalised so the scores for a single text sum to 1.
+
+```python
+from lingua_podre import predict_lang, get_lang_scores
+
+print(predict_lang("olá o meu nome é João"))
+# ['pt']
+print(predict_lang("hello my name is Bob"))
+# ['en']
+```
+
+`predict_lang` returns a **list** of [ISO 639-1] codes, not a single string,
+because two languages can tie for the top score.
+
+## 3. First real call
+
+```python
+from lingua_podre import predict_lang, get_lang_scores
+
+text = "olá o meu nome é João"
+print(predict_lang(text))       # ['pt']
+print(get_lang_scores(text))    # {'pt': 0.28..., 'ro': 0.14..., 'it': 0.14..., ...}
+```
+
+`get_lang_scores` gives you the full normalised distribution over the languages
+that matched at least one token. Languages with no matches do not appear in the
+dict. The values sum to 1.
+
+## 4. The gotcha you will hit first
+
+If **none** of the tokens match any list — short text, a name, an emoji, a
+language that is not bundled — there is nothing to score. `get_lang_scores`
+returns an empty dict and `predict_lang` raises `ValueError` (it calls `max()`
+on an empty sequence). Guard it:
+
+```python
+from lingua_podre import predict_lang
+
+def safe_predict(text):
+    try:
+        return predict_lang(text)
+    except ValueError:
+        return []          # undetectable: no known words matched
+
+print(safe_predict("xyzzy"))    # []
+```
+
+See [advanced.md](advanced.md) for the rest of the edge cases.
+
+## Where next
+
+- [api.md](api.md) — every public function, its signature, and its return shape
+- [advanced.md](advanced.md) — ties, thresholds, supported languages, recipes
+- [opm.md](opm.md) — using it as an OVOS language-detector plugin

--- a/examples/01_predict.py
+++ b/examples/01_predict.py
@@ -1,0 +1,25 @@
+"""Example — predict the language of a few short texts.
+
+Run::
+
+    python examples/01_predict.py
+"""
+from lingua_podre import predict_lang
+
+
+SAMPLES = [
+    "olá o meu nome é João",          # Portuguese
+    "hello my name is Bob",            # English
+    "hola me llamo Juan",              # Spanish
+    "bonjour je suis ravi de vous",    # French
+]
+
+
+def main() -> None:
+    for text in SAMPLES:
+        # predict_lang returns a list of codes (ties are possible).
+        print(f"{predict_lang(text)!s:10} <- {text}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_scores.py
+++ b/examples/02_scores.py
@@ -1,0 +1,23 @@
+"""Example — read the full normalised score distribution, not just the winner.
+
+Run::
+
+    python examples/02_scores.py
+"""
+from lingua_podre import get_lang_scores
+
+
+def main() -> None:
+    text = "olá o meu nome é João e gosto de música"
+    scores = get_lang_scores(text)          # values sum to 1
+
+    print(f"text: {text}")
+    print(f"languages that matched: {len(scores)}")
+    ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+    for code, prob in ranked[:5]:
+        bar = "#" * round(prob * 40)
+        print(f"  {code}  {prob:6.1%}  {bar}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_safe_detect.py
+++ b/examples/03_safe_detect.py
@@ -1,0 +1,31 @@
+"""Example — guard undetectable input so predict_lang never raises.
+
+Text with no words in any bundled list makes get_lang_scores divide by zero and
+predict_lang raise ValueError. A cheap pre-check on get_word_counts avoids it.
+
+Run::
+
+    python examples/03_safe_detect.py
+"""
+from lingua_podre import predict_lang, get_word_counts
+
+
+def safe_predict(text: str) -> list:
+    if not get_word_counts(text):       # no token matched anything
+        return []
+    return predict_lang(text)
+
+
+def main() -> None:
+    samples = [
+        "olá mundo",        # detectable Portuguese
+        "xyzzy",             # nonsense, nothing matches
+        "qwerty zzz",        # nonsense, nothing matches
+        "hello there",       # detectable English
+    ]
+    for text in samples:
+        print(f"{safe_predict(text)!s:10} <- {text!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_tokenize_counts.py
+++ b/examples/04_tokenize_counts.py
@@ -1,0 +1,24 @@
+"""Example — inspect the raw signal: tokens and per-language word counts.
+
+Run::
+
+    python examples/04_tokenize_counts.py
+"""
+from lingua_podre import tokenize, get_word_counts
+
+
+def main() -> None:
+    text = "o meu nome é João e o teu nome é Maria"
+
+    tokens = tokenize(text)             # lowercase, split on spaces
+    print("tokens:", tokens)
+
+    counts = get_word_counts(tokens)    # accepts a pre-tokenised list
+    ranked = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)
+    print("word hits per language:")
+    for code, n in ranked:
+        print(f"  {code}: {n}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_languages.py
+++ b/examples/05_languages.py
@@ -1,0 +1,22 @@
+"""Example — list the active languages and resolve names to codes.
+
+Run::
+
+    python examples/05_languages.py
+"""
+from lingua_podre import langs, lang_codes, stopwords
+
+
+def main() -> None:
+    print(f"active languages: {len(langs)}")
+    for code, name in sorted(langs.items()):
+        loaded = len(stopwords.get(code, []))
+        print(f"  {code}  {name:<12} ({loaded} words loaded)")
+
+    print()
+    print("portuguese ->", lang_codes["portuguese"])
+    print("pt ->", langs["pt"])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06_confidence_threshold.py
+++ b/examples/06_confidence_threshold.py
@@ -1,0 +1,37 @@
+"""Example — turn the score distribution into a confident label or "unsure".
+
+Accept the top language only when it clears a probability floor and beats the
+runner-up by a margin; otherwise report the text as ambiguous.
+
+Run::
+
+    python examples/06_confidence_threshold.py
+"""
+from lingua_podre import get_lang_scores, get_word_counts
+
+
+def confident_label(text: str, floor: float = 0.25, margin: float = 0.05):
+    if not get_word_counts(text):
+        return None, "no known words"
+    ranked = sorted(get_lang_scores(text).items(),
+                    key=lambda kv: kv[1], reverse=True)
+    top_code, top_p = ranked[0]
+    runner_p = ranked[1][1] if len(ranked) > 1 else 0.0
+    if top_p >= floor and (top_p - runner_p) >= margin:
+        return top_code, f"{top_p:.0%}"
+    return None, f"ambiguous (top {top_code} at {top_p:.0%})"
+
+
+def main() -> None:
+    samples = [
+        "olá o meu nome é João e gosto muito de música portuguesa",
+        "the quick brown fox jumps over the lazy dog",
+        "a o e",                         # function words, no real signal
+    ]
+    for text in samples:
+        label, why = confident_label(text)
+        print(f"{label!s:6} [{why}] <- {text}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a house-style `docs/` directory and a `examples/` directory for the language detector.

## docs/
- `quickstart.md` — install, the word-list scoring idea, first call, and the empty-input guard.
- `api.md` — every public function and module datum with real signatures and return shapes.
- `advanced.md` — ties, undetectable input, custom tokenisers, confidence thresholds, supported languages.
- `opm.md` — the `LinguaPodrePlugin` OVOS language-detector wrapper and its entry point.

## examples/
Six numbered runnable scripts using only the public API and stdlib, with inline Portuguese, English, Spanish, and French sample text:
- `01_predict.py` — predict language of short texts.
- `02_scores.py` — read the normalised score distribution.
- `03_safe_detect.py` — guard undetectable input.
- `04_tokenize_counts.py` — inspect tokens and per-language word counts.
- `05_languages.py` — list active languages and resolve names to codes.
- `06_confidence_threshold.py` — turn scores into a confident label or "unsure".

All six run to completion and print illustrative output.